### PR TITLE
added setuptools to setup.py, fixed a few #HACKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   
 notifications:
   email: false
- 
+  slack: slac-suncat:uMRwgQgYaSJFNr48PlZ1vtuf
+
 # Setup anaconda
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/catmap/mappers/mapper_base.py
+++ b/catmap/mappers/mapper_base.py
@@ -102,22 +102,7 @@ class MapperBase(ReactionModelWrapper):
                 ismapped = True
 
         if ismapped == False:
-            #HACK - the following code is copy-pasted from min_resid_mapper.
-            #need to abstract it out.
-            resolution = np.array(resolution)
-            if resolution.size == 1:
-                resx = resy = float(resolution)
-            elif resolution.size == 2:
-                resx = resolution[0]
-                resy = resolution[1]
-            else:
-                raise ValueError('Resolution is not the correct shape')
-
-            d1min,d1max = descriptor_ranges[0]
-            d2min,d2max = descriptor_ranges[1]
-            d1Vals = np.linspace(d1min,d1max,resx)
-            d2Vals = np.linspace(d2min,d2max,resy)
-            #ENDHACK
+            d1Vals, d2Vals = self.process_resolution()
             for d1V in d1Vals:
                 for d2V in d2Vals:
                     self._descriptors = [d1V,d2V]
@@ -136,3 +121,24 @@ class MapperBase(ReactionModelWrapper):
             if getattr(self,out+'_map_file'):
                 outfile = getattr(self,out+'_map_file')
                 self.save_map(mapp,outfile)
+    
+    def process_resolution(self, descriptor_ranges = None, resolution = None):
+        if not descriptor_ranges:
+            descriptor_ranges = self.descriptor_ranges
+        if resolution is None:
+            resolution = self.resolution
+        resolution = np.array(resolution)
+        if resolution.size == 1:
+            resx = resy = float(resolution)
+        elif resolution.size ==2:
+            resx = resolution[0]
+            resy = resolution[1]
+        else:
+            raise ValueError('Resolution is not the correct shape')
+
+        d1min, d1max = descriptor_ranges[0]
+        d2min, d2max = descriptor_ranges[1]
+        d1Vals = np.linspace(d1min, d1max, resx)
+        d2Vals = np.linspace(d2min, d2max, resy)
+        return d1Vals, d2Vals
+

--- a/catmap/mappers/min_resid_mapper.py
+++ b/catmap/mappers/min_resid_mapper.py
@@ -240,34 +240,15 @@ class MinResidMapper(MapperBase):
 
     def get_coverage_map(self, descriptor_ranges=None, resolution = None,
             initial_guess_adsorbate_names=None):
-        """Creates coverage map by computing residuals from nearby points
-        and trying points with lowest residuals first"""
-        if not descriptor_ranges:
-            descriptor_ranges = self.descriptor_ranges
-        if resolution is None:
-            resolution = self.resolution
+        """
+        Creates coverage map by computing residuals from nearby points
+        and trying points with lowest residuals first
+        """
+        d1Vals, d2Vals = self.process_resolution(descriptor_ranges, resolution)
+        d1Vals = d1Vals[::-1]
+        d2Vals = d2Vals[::-1]
 
-        resolution = np.array(resolution)
-        if resolution.size == 1:
-            resx = resy = float(resolution)
-        elif resolution.size == 2:
-            resx = resolution[0]
-            resy = resolution[1]
-        else:
-            raise ValueError('Resolution is not the correct shape')
-
-        d1min,d1max = descriptor_ranges[0]
-        d2min,d2max = descriptor_ranges[1]
-        d1Vals = np.linspace(d1min,d1max,resx)
-        d2Vals = np.linspace(d2min,d2max,resy)
-        def rev_nparray(nparray):
-            nparray = list(nparray)
-            nparray.reverse()
-            return np.array(nparray)
-        d1Vals = rev_nparray(d1Vals)
-        d2Vals = rev_nparray(d2Vals)
-
-        isMapped = np.zeros((resx,resy)) #matrix to track which
+        isMapped = np.zeros((len(d1Vals),len(d2Vals))) #matrix to track which
         #values have been checked/which directions have been searched
         maxNum = int('1'*len(self.search_directions),2) #if number is higher
         #than this then the point should not be checked

--- a/catmap/solvers/mean_field_solver.py
+++ b/catmap/solvers/mean_field_solver.py
@@ -209,8 +209,7 @@ class MeanFieldSolver(SolverBase):
         for i,p in enumerate(current_Ps):
             new_p = copy(current_Ps)
             new_p[i] = current_Ps[i]*(1+epsilon)
-            self._rxm.gas_pressures = new_p ##HACK
-            #setting self.gas_pressures = new_p inexplicably breaks the solver.
+            self.gas_pressures = new_p
             new_tofs = self.get_turnover_frequency(rxn_parameters)
             DRC_i = []
             for j,old_tof,new_tof,gas in zip(
@@ -225,8 +224,7 @@ class MeanFieldSolver(SolverBase):
                 dP = (new_p[i] - current_Ps[i])/current_Ps[i]
                 DRC_i.append(float(dTOF/dP))
             DRC.append(DRC_i)
-        self._rxm.gas_pressures = current_Ps ##HACK
-        #setting self.gas_pressures = current_Ps inexplicably breaks the solver.
+        self.gas_pressures = current_Ps 
         self._rxn_order = DRC
         return DRC
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 """Catalysis Micro-kinetic Analysis Package (CatMAP)"""
 
 import os
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from catmap import __version__ as version
 
 maintainer = 'Andrew J. Medford'


### PR DESCRIPTION
Added setuptools import to setup.py, defaults to distutils if importing setuptools fails.  This enables some more sophisticated installation flags.

Also changes a few things labeled "#HACK", including an abstraction request in MapperBase and a few assignments in mean_field_solver that seem to be resolved now.