### PR TITLE
Feature scipy optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   
 notifications:
   email: false
-  slack: slac-suncat:$SLACK_TOKEN
+  slack: slac-suncat:uMRwgQgYaSJFNr48PlZ1vtuf
 
 # Setup anaconda
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,7 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 # Install packages
 install:
-  - if [ "x${WITH_SCIPY}" == "xtrue" ]
-  - then
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose
-  - else
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy matplotlib nose
-  - fi
+  - if [ "x${WITH_SCIPY}" == "xtrue" ]; then conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose; else conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy matplotlib nose; fi
   - pip install mpmath
   - pip install python-ase
   - python setup.py install #install catmap

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy matplotlib nose
   - pip install mpmath
   - pip install python-ase
   - python setup.py install #install catmap

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ notifications:
   email: false
   slack: slac-suncat:uMRwgQgYaSJFNr48PlZ1vtuf
 
+env:
+    matrix:
+      - WITH_SCIPY=true
+      - WITH_SCIPY=false
+
 # Setup anaconda
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -21,7 +26,12 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 # Install packages
 install:
+  - if [ "x${WITH_SCIPY}" == "xtrue" ]
+  - then
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose
+  - else
   - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy matplotlib nose
+  - fi
   - pip install mpmath
   - pip install python-ase
   - python setup.py install #install catmap

--- a/catmap/__init__.py
+++ b/catmap/__init__.py
@@ -10,7 +10,11 @@ from string import Template
 
 #Non-standard dependencies
 import numpy as np
-from scipy.interpolate import InterpolatedUnivariateSpline as spline
+try:
+    from scipy.interpolate import InterpolatedUnivariateSpline as spline
+except ImportError:
+    spline = None
+    
 import matplotlib as mpl
 mpl.use('Agg')
 import pylab as plt

--- a/catmap/__init__.py
+++ b/catmap/__init__.py
@@ -13,8 +13,13 @@ import numpy as np
 try:
     from scipy.interpolate import InterpolatedUnivariateSpline as spline
 except ImportError:
-    spline = None
-    
+    def spline_wrapper(x_data, y_data, k=3):  # input kwarg k is intentionally ignored
+        # behaves like scipy.interpolate.InterpolatedUnivariateSpline for k=1
+        def spline_func(x):
+            return np.interp(x, map(float,x_data), map(float,y_data))  # loss of precision here
+        return spline_func
+    spline = spline_wrapper
+
 import matplotlib as mpl
 mpl.use('Agg')
 import pylab as plt
@@ -66,7 +71,7 @@ class ReactionModelWrapper:
         else:
             if attr in self.__dict__:
                 val =  object.__getattribute__(self,attr)
-                del self.__dict__[attr] 
+                del self.__dict__[attr]
                 #this makes sure that the attr is read from _rxm
                 setattr(self._rxm,attr,val)
                 return val

--- a/catmap/analyze/analysis_base.py
+++ b/catmap/analyze/analysis_base.py
@@ -3,7 +3,10 @@ from catmap import ReactionModelWrapper
 from catmap.model import ReactionModel as RM
 from catmap import griddata
 from copy import copy
-from scipy.stats import norm
+try:
+    from scipy.stats import norm
+except:
+    norm = None
 from matplotlib.ticker import MaxNLocator
 import os
 import math

--- a/catmap/solvers/steady_state_solver.py
+++ b/catmap/solvers/steady_state_solver.py
@@ -1,7 +1,11 @@
 from solver_base import *
 from mean_field_solver import *
 from catmap import string2symbols
-from scipy.optimize import fmin_powell as fmin
+try:
+    from scipy.optimize import fmin_powell as fmin
+except ImportError:
+    fmin = None
+
 from catmap.functions import numerical_jacobian
 import math
 from string import Template

--- a/catmap/thermodynamics/enthalpy_entropy.py
+++ b/catmap/thermodynamics/enthalpy_entropy.py
@@ -2,7 +2,11 @@ import catmap
 from catmap import ReactionModelWrapper
 from catmap.model import ReactionModel
 from catmap.functions import get_composition, add_dict_in_place
-from scipy.optimize import fmin_powell
+try:
+    from scipy.optimize import fmin_powell
+except ImportError:
+    fmin_powell = None
+
 import warnings
 from mpmath import mpf
 from math import exp, log
@@ -818,7 +822,11 @@ class ThermoCorrections(ReactionModelWrapper):
 
 
 def fit_shomate(Ts, Cps, Hs, Ss, params0,plot_file = None):
-    from scipy.optimize import leastsq
+    try:
+        from scipy.optimize import leastsq
+    except ImportError:
+        leastsq = None
+
     def H(t,A,B,C,D,E,F,H_c):
         H = A*t + (B/2.0)*t**2 + (C/3.0)*t**3 + (D/4.0)*t**4 - E/t + F - H_c 
         #kJ/mol

--- a/catmap/thermodynamics/first_order_interactions.py
+++ b/catmap/thermodynamics/first_order_interactions.py
@@ -5,8 +5,14 @@ from catmap.functions import smooth_piecewise_linear
 from catmap.functions import parse_constraint
 import pylab as plt
 import numpy as np
-from scipy import integrate
-from scipy.optimize import fmin
+
+try:
+    from scipy.optimize import fmin
+    from scipy import integrate
+except ImportError:
+    fmin = None
+    integrate = None
+
 from itertools import combinations_with_replacement as combinations
 
 class FirstOrderInteractions(ReactionModelWrapper):

--- a/catmap/thermodynamics/second_order_interactions.py
+++ b/catmap/thermodynamics/second_order_interactions.py
@@ -7,7 +7,10 @@ from catmap.functions import parse_constraint
 from catmap.thermodynamics import FirstOrderInteractions
 import pylab as plt
 import numpy as np
-from scipy import integrate
+try:
+    from scipy import integrate
+except ImportError:
+    integrate = None
 
 class SecondOrderInteractions(FirstOrderInteractions,ReactionModelWrapper):
     """Class for implementing 'first-order adsorbate interaction model. 

--- a/test_dependencies.py
+++ b/test_dependencies.py
@@ -1,5 +1,8 @@
 import numpy
-import scipy
+try:
+    import scipy
+except:
+    print("Warning: scipy could not be imported! Some of the advanced features such as higher-order adsorbate-adsorbate interaction relying on arbitrary precision arithmethic may not for properly. Please install scipy for full feature support.")
 import pylab
 import mpmath
 import ase


### PR DESCRIPTION
Rationale: if you happen to use CatMAP in an environment where for whatever reason scipy cannot be installed catmap can still be useful for some applications. I.e. the fact that scipy is not installed does not become an immediate showstopper. scipy is always a problematic dependency, but not having it shouldn't stop anyone from using CatMAP completely ...

This seems pretty straightforward and all tests pass with optional scipy blocks. Still, does anyone see any unwanted side-effects?