### PR TITLE
Feature all output variables by code inspection.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
   - python mkm_job.py
   - cd ../output_variables
   - python mkm_job.py
+  - python mkm_job_output_all.py
   - cd ../electrochemistry/HER
   - python mkm_job.py
   - cd ../ORR_scaling

--- a/catmap/model.py
+++ b/catmap/model.py
@@ -136,6 +136,19 @@ class ReactionModel:
         for key in kwargs:
             setattr(self,key,kwargs[key])
 
+        # if 'all' is in output_variables, expand it to all processed output_variables
+        # note that this expansion needs to happen in ReactionModel.run and not
+        # ReactionModel.__init__ or it will not be caught in the mkm_job.py
+        if 'all' in self.output_variables:
+            import catmap.functions
+            self.output_variables.remove('all')
+            self.output_variables = sorted(list(
+                set(self.output_variables).union(
+                    set(
+                        catmap.functions.fetch_all_output_variables()
+                    )
+                )
+            ))
 
         #ensure resolution has the proper dimensions
         if not hasattr(self.resolution,'__iter__'):

--- a/catmap/solvers/solver_base.py
+++ b/catmap/solvers/solver_base.py
@@ -99,6 +99,9 @@ class SolverBase(ReactionModelWrapper):
             self.output_labels['directional_rates'] = [str(rxn) + ' forward' for rxn in self.elementary_rxns] + \
                 [str(rxn) + ' reverse' for rxn in self.elementary_rxns]
 
+        if 'turnover_frequency' in self.output_variables:
+            self.output_labels['turnover_frequency'] = self.gas_names
+
         for out in self.output_variables:
             if out == 'production_rate':
                 self._production_rate = [max(0,r) 

--- a/catmap/thermodynamics/enthalpy_entropy.py
+++ b/catmap/thermodynamics/enthalpy_entropy.py
@@ -452,7 +452,7 @@ class ThermoCorrections(ReactionModelWrapper):
                     frequencies = [max(nu,nu_min) for nu in frequencies]
                 therm = HarmonicThermo(frequencies)
                 try:
-                    free_energy = therm.get_gibbs_energy(
+                    free_energy = therm.get_helmholtz_energy(
                             temperature,verbose=False)
                 except AttributeError:
                     warnings.warn('HarmonicThermo.get_free_energy is deprecated.'

--- a/tutorials/electrochemistry/ORR_scaling/make_input.py
+++ b/tutorials/electrochemistry/ORR_scaling/make_input.py
@@ -1,6 +1,9 @@
 import sys
 import numpy as np
-from ase.all import string2symbols
+try:
+    from ase.atoms import string2symbols
+except:
+    from ase.all import string2symbols
 import string
 
 """this script creates a CatMap input file that attempts to match the data in Hansen et al. (2014)

--- a/tutorials/electrochemistry/ORR_thermo/make_input.py
+++ b/tutorials/electrochemistry/ORR_thermo/make_input.py
@@ -1,6 +1,11 @@
 import sys
 import numpy as np
-from ase.all import string2symbols
+
+try:
+    from ase.atoms import string2symbols
+except:
+    from ase.all import string2symbols
+
 import string
 
 """this script creates a CatMap input file that attempts to match the data in Hansen et al. (2014)

--- a/tutorials/output_variables/mkm_job_output_all.py
+++ b/tutorials/output_variables/mkm_job_output_all.py
@@ -1,0 +1,51 @@
+"""This mkm_job script generates the same results as the tutorialsoutput_variables/mkm_job.py script
+however it demonstrates that values of output_variables do not need to be all hard-coded
+
+FIXME: At this point we still need to hard-code two-dimensional variables, since this is difficult to glean from code inspection only.
+FIXME: Output variables 'turnover_frequency' and 'interaction_matrix' currently crash, we should fix them or remove them from the parser.
+
+"""
+from catmap import ReactionModel
+from catmap import analyze
+
+mkm_file = 'CO_oxidation.mkm'
+model = ReactionModel(setup_file=mkm_file)
+model.output_variables = ['all']  # <==== Here is where the 'all' magic happens
+two_dim_variables = ['rate_control', 'selectivity_control',
+                     'rxn_order', 'frequency', 'interaction_matrix']
+# !!! However we still need to hard-code those variables that are supposed to go through MatrixMap instead of VectorMap
+model.run()
+
+vm = analyze.VectorMap(model)
+mm = analyze.MatrixMap(model)
+
+for output_variable in model.output_variables:
+    m = mm if output_variable in two_dim_variables else vm
+    plot_type = 'MatrixMap' if output_variable in two_dim_variables else 'VectorMap'
+
+    if output_variable is None:
+        pass
+    # put other adjustments here
+    # elif output_variable == '...':
+    #     m.<attr> = '...'
+    elif output_variable == 'turnover_frequency':
+        continue  # crashes, should get fixed
+    elif output_variable == 'interaction_matrix':
+        continue  # crashes, should get fixed
+    else:  # set default values
+        # not necessarily the right choice of parameters for all
+        # output_variables
+        vm.log_scale = True
+        vm.min = 1e-25
+        vm.max = 1e3
+        vm.threshold = 1e-25
+        vm.unique_only = False
+        mm.log_scale = False
+        mm.min = -2
+        mm.max = 2
+        mm.unique_only = False
+    print(
+        "Plotting {output_variable}, plot type: {plot_type}".format(**locals()))
+    m.plot_variable = output_variable
+    fig = m.plot(save='ALL_{output_variable}.pdf'.format(**locals()))
+    fig.clf()

--- a/tutorials/output_variables/mkm_job_output_all.py
+++ b/tutorials/output_variables/mkm_job_output_all.py
@@ -19,6 +19,17 @@ model.run()
 vm = analyze.VectorMap(model)
 mm = analyze.MatrixMap(model)
 
+def set_defaults(vm, mm):
+    vm.log_scale = True
+    vm.min = 1e-25
+    vm.max = 1e3
+    vm.threshold = 1e-25
+    vm.unique_only = False
+    mm.log_scale = False
+    mm.min = -2
+    mm.max = 2
+    mm.unique_only = False
+
 for output_variable in model.output_variables:
     m = mm if output_variable in two_dim_variables else vm
     plot_type = 'MatrixMap' if output_variable in two_dim_variables else 'VectorMap'
@@ -28,22 +39,12 @@ for output_variable in model.output_variables:
     # put other adjustments here
     # elif output_variable == '...':
     #     m.<attr> = '...'
-    elif output_variable == 'turnover_frequency':
-        continue  # crashes, should get fixed
     elif output_variable == 'interaction_matrix':
-        continue  # crashes, should get fixed
+        continue  # only works for model with adsorbate-adsorbate interaction
     else:  # set default values
         # not necessarily the right choice of parameters for all
         # output_variables
-        vm.log_scale = True
-        vm.min = 1e-25
-        vm.max = 1e3
-        vm.threshold = 1e-25
-        vm.unique_only = False
-        mm.log_scale = False
-        mm.min = -2
-        mm.max = 2
-        mm.unique_only = False
+        set_defaults(vm, mm)
     print(
         "Plotting {output_variable}, plot type: {plot_type}".format(**locals()))
     m.plot_variable = output_variable


### PR DESCRIPTION
A little overdue, I present the code-inspection function for output_variables. By doing so that I noticed that `turnover_frequency` and `interaction_matrix` are apparently not working with the standard tutorial. What is the situation here?

I demo the feature in a new script `tutorials/output_variables/mkm_job_output_all.py` which ramps the Travis turn-around time to almost 6 minutes. Maybe one should talk about running test in parallel?