### PR TITLE
Feature code coverage and test parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,26 +34,29 @@ install:
 # Run tests; this is a very crude way of testing things
 # We should move to a more elegant strategy in the future
 script:
-  - coverage run --source=catmap -a test_dependencies.py
+  - coverage run --include='*catmap*' -a test_dependencies.py
   - cd tutorials/1-generating_input_file
-  - coverage run --source=catmap -a generate_input.py
+  - coverage run --include='*catmap*' -a generate_input.py
   - cd ../2-creating_microkinetic_model
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a mkm_job.py
   - cd ../3-refining_microkinetic_model
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a mkm_job.py
   - cd ../thermodynamic_descriptors
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a mkm_job.py
   - cd ../output_variables
-  - coverage run --source=catmap -a mkm_job.py
-  - coverage run --source=catmap -a mkm_job_output_all.py
+  - coverage run --include='*catmap*' -a mkm_job.py
+  - coverage run --include='*catmap*' -a mkm_job_output_all.py
   - cd ../electrochemistry/HER
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a mkm_job.py
   - cd ../ORR_scaling
-  - coverage run --source=catmap -a make_input.py
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a make_input.py
+  - coverage run --include='*catmap*' -a mkm_job.py
   - cd ../ORR_thermo
-  - coverage run --source=catmap -a make_input.py
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a make_input.py
+  - coverage run --include='*catmap*' -a mkm_job.py
   - cd ../electrons
-  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --include='*catmap*' -a mkm_job.py
+  # Go up one directory and collect the coverage results from all directory below
+  - cd ..
+  - coverage combined $(ls -d */)
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,26 +34,27 @@ install:
 # Run tests; this is a very crude way of testing things
 # We should move to a more elegant strategy in the future
 script:
-  - coverage run -a --include='catmap/*' test_dependencies.py
+  - coverage run -a test_dependencies.py
   - cd tutorials/1-generating_input_file
-  - coverage run -a --include='catmap/*' generate_input.py
+  - coverage run -a generate_input.py
   - cd ../2-creating_microkinetic_model
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a mkm_job.py
   - cd ../3-refining_microkinetic_model
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a mkm_job.py
   - cd ../thermodynamic_descriptors
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a mkm_job.py
   - cd ../output_variables
-  - coverage run -a --include='catmap/*' mkm_job.py
-  - coverage run -a --include='catmap/*' mkm_job_output_all.py
+  - coverage run -a mkm_job.py
+  - coverage run -a mkm_job_output_all.py
   - cd ../electrochemistry/HER
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a mkm_job.py
   - cd ../ORR_scaling
-  - coverage run -a --include='catmap/*' make_input.py
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a make_input.py
+  - coverage run -a mkm_job.py
   - cd ../ORR_thermo
-  - coverage run -a --include='catmap/*' make_input.py
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a make_input.py
+  - coverage run -a mkm_job.py
   - cd ../electrons
-  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a mkm_job.py
   - coverage combine
+  - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,29 +34,17 @@ install:
 # Run tests; this is a very crude way of testing things
 # We should move to a more elegant strategy in the future
 script:
-  - coverage run --include='*catmap*' -a test_dependencies.py
-  - cd tutorials/1-generating_input_file
-  - coverage run --include='*catmap*' -a generate_input.py
-  - cd ../2-creating_microkinetic_model
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - cd ../3-refining_microkinetic_model
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - cd ../thermodynamic_descriptors
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - cd ../output_variables
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - coverage run --include='*catmap*' -a mkm_job_output_all.py
-  - cd ../electrochemistry/HER
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - cd ../ORR_scaling
-  - coverage run --include='*catmap*' -a make_input.py
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - cd ../ORR_thermo
-  - coverage run --include='*catmap*' -a make_input.py
-  - coverage run --include='*catmap*' -a mkm_job.py
-  - cd ../electrons
-  - coverage run --include='*catmap*' -a mkm_job.py
+  - coverage run --include='*catmap*' -a test_dependencies.py &
+  - cd tutorials/1-generating_input_file ; coverage run --include='*catmap*' -a generate_input.py &
+  - cd 2-creating_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd 3-refining_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd thermodynamic_descriptors ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd output_variables ; coverage run --include='*catmap*' -a mkm_job.py ; coverage run --include='*catmap*' -a mkm_job_output_all.py &
+  - cd electrochemistry/HER ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd ORR_scaling ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd ORR_thermo ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd electrons ; coverage run --include='*catmap*' -a mkm_job.py &
   # Go up one directory and collect the coverage results from all directory below
-  - cd ..
-  - coverage combine $(ls -d */)
+  - wait # wait for all background-jobs to finish
+  - coverage combine $(find . -name '*.coverage')
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,26 +34,26 @@ install:
 # Run tests; this is a very crude way of testing things
 # We should move to a more elegant strategy in the future
 script:
-  - coverage run -a test_dependencies.py
+  - coverage run --source=catmap -a test_dependencies.py
   - cd tutorials/1-generating_input_file
-  - coverage run -a generate_input.py
+  - coverage run --source=catmap -a generate_input.py
   - cd ../2-creating_microkinetic_model
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a mkm_job.py
   - cd ../3-refining_microkinetic_model
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a mkm_job.py
   - cd ../thermodynamic_descriptors
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a mkm_job.py
   - cd ../output_variables
-  - coverage run -a mkm_job.py
-  - coverage run -a mkm_job_output_all.py
+  - coverage run --source=catmap -a mkm_job.py
+  - coverage run --source=catmap -a mkm_job_output_all.py
   - cd ../electrochemistry/HER
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a mkm_job.py
   - cd ../ORR_scaling
-  - coverage run -a make_input.py
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a make_input.py
+  - coverage run --source=catmap -a mkm_job.py
   - cd ../ORR_thermo
-  - coverage run -a make_input.py
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a make_input.py
+  - coverage run --source=catmap -a mkm_job.py
   - cd ../electrons
-  - coverage run -a mkm_job.py
+  - coverage run --source=catmap -a mkm_job.py
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,31 +28,32 @@ before_install:
 install:
   - if [ "x${WITH_SCIPY}" == "xtrue" ]; then conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose; else conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy matplotlib nose; fi
   - pip install mpmath
-  - pip install ase
+  - pip install ase coverage
   - python setup.py install #install catmap
  
 # Run tests; this is a very crude way of testing things
 # We should move to a more elegant strategy in the future
 script:
-  - python test_dependencies.py
+  - coverage run -a --include='catmap/*' test_dependencies.py
   - cd tutorials/1-generating_input_file
-  - python generate_input.py
+  - coverage run -a --include='catmap/*' generate_input.py
   - cd ../2-creating_microkinetic_model
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' mkm_job.py
   - cd ../3-refining_microkinetic_model
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' mkm_job.py
   - cd ../thermodynamic_descriptors
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' mkm_job.py
   - cd ../output_variables
-  - python mkm_job.py
-  - python mkm_job_output_all.py
+  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage run -a --include='catmap/*' mkm_job_output_all.py
   - cd ../electrochemistry/HER
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' mkm_job.py
   - cd ../ORR_scaling
-  - python make_input.py
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' make_input.py
+  - coverage run -a --include='catmap/*' mkm_job.py
   - cd ../ORR_thermo
-  - python make_input.py
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' make_input.py
+  - coverage run -a --include='catmap/*' mkm_job.py
   - cd ../electrons
-  - python mkm_job.py
+  - coverage run -a --include='catmap/*' mkm_job.py
+  - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,4 @@ script:
   - coverage run -a mkm_job.py
   - cd ../electrons
   - coverage run -a mkm_job.py
-  - coverage combine
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,5 +58,5 @@ script:
   - coverage run --include='*catmap*' -a mkm_job.py
   # Go up one directory and collect the coverage results from all directory below
   - cd ..
-  - coverage combined $(ls -d */)
+  - coverage combine $(ls -d */)
   - coverage report


### PR DESCRIPTION
I tinkered a bit more with travis: the attached PR produces a coverage report telling us exactly how much of each source code file is covered by the tutorial tests. Checkout the [documentation](http://coverage.readthedocs.org/en/coverage-4.0.3/). It is easy to install locally using pip and one can even annotate source code files with it.

The second thing is a poor man's approach for running the tests in parallel. We will have to keep an eye open, once we get too many test and run danger of running out of memory on the VM. But that will at least show loudly and for now it brings the turn-around time to under 2 minutes!