### PR TITLE
Undo parallel test execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,17 +34,17 @@ install:
 # Run tests; this is a very crude way of testing things
 # We should move to a more elegant strategy in the future
 script:
-  - coverage run --include='*catmap*' -a test_dependencies.py &
-  - cd tutorials/1-generating_input_file && coverage run --include='*catmap*' -a generate_input.py &
-  - cd tutorials/2-creating_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/3-refining_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/thermodynamic_descriptors && coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/output_variables && coverage run --include='*catmap*' -a mkm_job.py && coverage run --include='*catmap*' -a mkm_job_output_all.py &
-  - cd tutorials/electrochemistry/HER && coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/electrochemistry/ORR_scaling && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py &
-  # Go up one directory and collect the coverage results from all directory below
-  - for job in $(jobs -p); do wait ${job} && echo "${job} passed" || echo "${job} failed";  done
+  - coverage run --include='*catmap*' -a test_dependencies.py
+  - popd tutorials/1-generating_input_file && coverage run --include='*catmap*' -a generate_input.py && popd
+  - popd tutorials/2-creating_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - popd tutorials/3-refining_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - popd tutorials/thermodynamic_descriptors && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - popd tutorials/output_variables && coverage run --include='*catmap*' -a mkm_job.py && coverage run --include='*catmap*' -a mkm_job_output_all.py && popd
+  - popd tutorials/electrochemistry/HER && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - popd tutorials/electrochemistry/ORR_scaling && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - popd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - popd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py && popd
+  # lets give up on parallel test execution because current Travis VM only runs on 1.5 virtual cores.
+  #- for job in $(jobs -p); do wait ${job} && echo "${job} passed" || echo "${job} failed";  done
   - coverage combine $(find . -name '*.coverage')
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ install:
 script:
   - coverage run --include='*catmap*' -a test_dependencies.py &
   - cd tutorials/1-generating_input_file ; coverage run --include='*catmap*' -a generate_input.py &
-  - cd 2-creating_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd 3-refining_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd thermodynamic_descriptors ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd output_variables ; coverage run --include='*catmap*' -a mkm_job.py ; coverage run --include='*catmap*' -a mkm_job_output_all.py &
-  - cd electrochemistry/HER ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd ORR_scaling ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd ORR_thermo ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd electrons ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/2-creating_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/3-refining_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/thermodynamic_descriptors ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/output_variables ; coverage run --include='*catmap*' -a mkm_job.py ; coverage run --include='*catmap*' -a mkm_job_output_all.py &
+  - cd tutorials/electrochemistry/HER ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/electrochemistry/ORR_scaling ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/electrochemistry/ORR_thermo ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/electrochemistry/electrons ; coverage run --include='*catmap*' -a mkm_job.py &
   # Go up one directory and collect the coverage results from all directory below
   - wait # wait for all background-jobs to finish
   - coverage combine $(find . -name '*.coverage')

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,6 @@ script:
   - cd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py &
   - cd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py &
   # Go up one directory and collect the coverage results from all directory below
-  - for job in $(jobs -p)
-  - do
-  -   wait ${job} || echo "${job} failed" # wait for all background-jobs to finish
-  - done
+  - for job in $(jobs -p); do wait ${job} || echo "${job} failed";  done
   - coverage combine $(find . -name '*.coverage')
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
   - cd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py &
   - cd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py &
   # Go up one directory and collect the coverage results from all directory below
-  - for job in $(jobs -p); do wait ${job} || echo "${job} failed";  done
+  - for job in $(jobs -p); do wait ${job} && echo "${job} passed" || echo "${job} failed";  done
   - coverage combine $(find . -name '*.coverage')
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,19 @@ install:
 # We should move to a more elegant strategy in the future
 script:
   - coverage run --include='*catmap*' -a test_dependencies.py &
-  - cd tutorials/1-generating_input_file ; coverage run --include='*catmap*' -a generate_input.py &
-  - cd tutorials/2-creating_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/3-refining_microkinetic_model ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/thermodynamic_descriptors ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/output_variables ; coverage run --include='*catmap*' -a mkm_job.py ; coverage run --include='*catmap*' -a mkm_job_output_all.py &
-  - cd tutorials/electrochemistry/HER ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/electrochemistry/ORR_scaling ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/electrochemistry/ORR_thermo ; coverage run --include='*catmap*' -a make_input.py ; coverage run --include='*catmap*' -a mkm_job.py &
-  - cd tutorials/electrochemistry/electrons ; coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/1-generating_input_file && coverage run --include='*catmap*' -a generate_input.py &
+  - cd tutorials/2-creating_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/3-refining_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/thermodynamic_descriptors && coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/output_variables && coverage run --include='*catmap*' -a mkm_job.py && coverage run --include='*catmap*' -a mkm_job_output_all.py &
+  - cd tutorials/electrochemistry/HER && coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/electrochemistry/ORR_scaling && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py &
+  - cd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py &
   # Go up one directory and collect the coverage results from all directory below
-  - wait # wait for all background-jobs to finish
+  - for job in $(jobs -p)
+  - do
+  -   wait ${job} || echo "${job} failed" # wait for all background-jobs to finish
+  - done
   - coverage combine $(find . -name '*.coverage')
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,15 @@ install:
 # We should move to a more elegant strategy in the future
 script:
   - coverage run --include='*catmap*' -a test_dependencies.py
-  - popd tutorials/1-generating_input_file && coverage run --include='*catmap*' -a generate_input.py && popd
-  - popd tutorials/2-creating_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py && popd
-  - popd tutorials/3-refining_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py && popd
-  - popd tutorials/thermodynamic_descriptors && coverage run --include='*catmap*' -a mkm_job.py && popd
-  - popd tutorials/output_variables && coverage run --include='*catmap*' -a mkm_job.py && coverage run --include='*catmap*' -a mkm_job_output_all.py && popd
-  - popd tutorials/electrochemistry/HER && coverage run --include='*catmap*' -a mkm_job.py && popd
-  - popd tutorials/electrochemistry/ORR_scaling && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py && popd
-  - popd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py && popd
-  - popd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/1-generating_input_file && coverage run --include='*catmap*' -a generate_input.py && popd
+  - pushd tutorials/2-creating_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/3-refining_microkinetic_model && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/thermodynamic_descriptors && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/output_variables && coverage run --include='*catmap*' -a mkm_job.py && coverage run --include='*catmap*' -a mkm_job_output_all.py && popd
+  - pushd tutorials/electrochemistry/HER && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/electrochemistry/ORR_scaling && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/electrochemistry/ORR_thermo && coverage run --include='*catmap*' -a make_input.py && coverage run --include='*catmap*' -a mkm_job.py && popd
+  - pushd tutorials/electrochemistry/electrons && coverage run --include='*catmap*' -a mkm_job.py && popd
   # lets give up on parallel test execution because current Travis VM only runs on 1.5 virtual cores.
   #- for job in $(jobs -p); do wait ${job} && echo "${job} passed" || echo "${job} failed";  done
   - coverage combine $(find . -name '*.coverage')


### PR DESCRIPTION
It turns out I should have read the [specs](https://docs.travis-ci.com/user/speeding-up-the-build/) before bothering with parallelizing test. They say that the test VMs are run on 1.5 virtual cores, so not much to gain from parallelization. The only other way would be to create several VMs and somehow orchestra them so that everyone runs a different test, but I am not sure this is worth the effort and computational overhead at this point.
I would still keep .travis.yml as in the patch attached since it seems fairly easy to modify (1 test per line) and furthermore it finally sums up the coverage across all tests.