### PR TITLE
Fixed pH module

### DIFF
--- a/catmap/thermodynamics/enthalpy_entropy.py
+++ b/catmap/thermodynamics/enthalpy_entropy.py
@@ -150,7 +150,7 @@ class ThermoCorrections(ReactionModelWrapper):
             G_H = 0.5*G_H2 - .0592*self.pH
             G_H2O = self._electronic_energy_dict['H2O_g'] + self._correction_dict['H2O_g']
             H2O_index = self.gas_names.index('H2O_g')
-            G_OH = G_H2O - G_H + self._kB*self.temperature*np.log(self.gas_pressures[H2O_index]*1.e14)
+            G_OH = G_H2O - G_H # Do not need Kw, just need to make sure equilibria are satisfied
             correction_dict['H_g'] = G_H
             correction_dict['OH_g'] = G_OH
 


### PR DESCRIPTION
I have fixed an error in the pH module -- the Kw correction is not needed because of how reference states are calculated. H+, OH-, and H2O must have the same energy at pH 0.