### PR TITLE
Add one basic sanity check for rxn_expression.

### DIFF
--- a/catmap/model.py
+++ b/catmap/model.py
@@ -587,6 +587,11 @@ class ReactionModel:
             # are separated from reactions by ";" and from each other by ","
             eq = rxn
             options = None
+            if rxn.count('->') > 2:
+                print(("Warning: reaction\n\n"
+                       "\t({rxn_index})\t{rxn}\n\n is very long!\n"
+                       "Make sure this is intended and there is no missing ',' (comma)\n"
+                       "at the end of the line.\n").format(**locals()))
             if ';' in rxn:
                 eq, options = rxn.split(';')
             if options:


### PR DESCRIPTION
The rxn_expressions is defined as a list of strings. If a comma is omitted, to rxn_expressions are implicitly concatenated together even with a python comment in between. This can be quite hard to see and did not result in a helpful error message.