### PR TITLE
Update installation instructions: clone from SUNCAT-Center

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ call it $CATMAP):
 .. code:: bash
     
     $ cd $CATMAP 
-    $ git clone https://github.com/ajmedford/catmap.git 
+    $ git clone https://github.com/SUNCAT-Center/catmap.git
 
 This will clone the
 repository into a directory called "catmap". Next, you need to add


### PR DESCRIPTION
The original installation instructions instruct the user to clone the forked catmap repository on A.J. Medford's GitHub account instead of the main repository from SUNCAT-Center. This is now updated accordingly.