### PR TITLE
Fixed ASE string2symbols references.

### DIFF
--- a/catmap/__init__.py
+++ b/catmap/__init__.py
@@ -41,7 +41,7 @@ def griddata(*args, **kwargs):
         return mlab_griddata(*args, **kwargs)
 
 import mpmath as mp
-from ase.atoms import string2symbols
+from ase.symbols import string2symbols
 from ase.thermochemistry import IdealGasThermo, HarmonicThermo
 try:
     from ase.build import molecule

--- a/catmap/functions.py
+++ b/catmap/functions.py
@@ -2,7 +2,7 @@ import numpy as np
 import catmap
 import re
 from copy import copy
-from ase.atoms import string2symbols
+from ase.symbols import string2symbols
 import warnings
 
 def get_composition(species_string):

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ else:
 url = 'https://github.com/ajmedford/catmap'
 
 setup(
-      author=author,
-      author_email=author_email,
+      author="Andrew J. Medford",
+      author_email="andrew.medford@chbe.gatech.edu",
       description=description,
       license=license,
       long_description=long_description,
@@ -76,6 +76,6 @@ setup(
       packages=packages,
       platforms=platforms,
       scripts=scripts,
-      url=url,
+      url="https://github.com/SUNCAT-Center/catmap",
       version=version,
       )


### PR DESCRIPTION
ASE string2symbols has been moved from ase.atoms to ase.symbols.