### PR TITLE
Fixed .log file.

### DIFF
--- a/catmap/model.py
+++ b/catmap/model.py
@@ -1150,7 +1150,7 @@ class ReactionModel:
         exec(self._log_imports) #needed for testing evaluation of log file
         #load in pickled data at the beginning
         header += 'binary_data = ' + 'pickle.load(open("' + \
-                                                self.data_file +'"))\n\n'
+                                                self.data_file +'","rb"))\n\n'
         header += 'locals().update(binary_data)\n\n'
         for attr in dir(self):
             if (not attr.startswith('_') and

--- a/tutorials/3-refining_microkinetic_model/CO_oxidation.mkm
+++ b/tutorials/3-refining_microkinetic_model/CO_oxidation.mkm
@@ -28,7 +28,7 @@ descriptor_names= ['O_s','CO_s'] #descriptor names
 
 descriptor_ranges = [[-1,3],[-0.5,4]]
 
-resolution = 29
+resolution = 34
 
 temperature = 500 #Temperature of the reaction
 

--- a/tutorials/electrochemistry/HER/HER.mkm
+++ b/tutorials/electrochemistry/HER/HER.mkm
@@ -12,7 +12,7 @@ descriptor_names = ['H_s','OH_s']
 
 descriptor_ranges = [[-1,1],[-2,3]]
 
-resolution = [15, 15]
+resolution = [17, 17]
 
 temperature = 300
 

--- a/tutorials/including_adsorbate_interactions/CO_oxidation.mkm
+++ b/tutorials/including_adsorbate_interactions/CO_oxidation.mkm
@@ -19,7 +19,7 @@ descriptor_names= ['O_s','CO_s'] #descriptor names
 
 descriptor_ranges = [[-1,3],[-0.5,4]]
 
-resolution = 15
+resolution = 24
 
 temperature = 500 #Temperature of the reaction
 

--- a/tutorials/second_order_interactions/mkm_job.py
+++ b/tutorials/second_order_interactions/mkm_job.py
@@ -1,7 +1,11 @@
 from catmap import ReactionModel
 from catmap import analyze
 import numpy as np
-import cPickle as pickle
+
+try:
+    import cPickle as pickle
+except:
+    import _pickle as pickle # Python 3.x
 
 
 include_overbinding = False


### PR DESCRIPTION
Fix for #122 
added 'rb' parameter when unpickling pkl files.
resolutions have been increased in `.mkm` files so that meshing work within this new meshgrid framework.