### PR TITLE
BUGFIX: Numbers solver

### DIFF
--- a/catmap/mappers/min_resid_mapper.py
+++ b/catmap/mappers/min_resid_mapper.py
@@ -593,7 +593,6 @@ class MinResidMapper(MapperBase):
                                                 [resid,sol_pt,cvg])
 
                                     checked_dirs[k] = 1
-
                                 if sol_cvgs:
                                     self._coverage = sol_cvgs
                                     if self.use_numbers_solver:

--- a/catmap/solvers/integrated_rate_control_solver.py
+++ b/catmap/solvers/integrated_rate_control_solver.py
@@ -45,12 +45,12 @@ class IntegratedRateControlSolver(SolverBase):
             for dname in self.descriptor_names:
                 Ef = self.species_definitions[dname]['formation_energy'][ref_idx]
                 desc_energies.append(Ef)
-            
+
             ref_dict = self.scaler.get_free_energies(desc_energies)
             self.reference_free_energies = ref_dict
             self._static_rate_controls = DRCs
             self._initialized = True
-        
+
         Gs = {}
         for key,G in zip(self.adsorbate_names + self.transition_state_names, params):
             Gs[key] = G

--- a/catmap/solvers/mean_field_solver.py
+++ b/catmap/solvers/mean_field_solver.py
@@ -349,7 +349,7 @@ class MeanFieldSolver(SolverBase):
             if (d_wrt not in sites # Not differentiating with respect to a site 
                 and d_idx in ads_idxs # Differentiating with respect to an adsorbate 
                 and d_site not in sites # Site not present in the rate expression 
-                and self.fix_x_star == True): # Fixing x_star
+                and (self.use_numbers_solver == False or self.fix_x_star == True)): # Fixing x_star
                 # Scenario 1: Differentiating with respect to an adsorbate
                 # but there is no site term in the rate equation. 
                 multiplier = ads_idxs.count(d_idx) #get order
@@ -389,7 +389,7 @@ class MeanFieldSolver(SolverBase):
 
             elif ( d_site in sites # Site present in the rate expression 
                   and d_idx not in ads_idxs # Adsorbates not present in the rate expression 
-                  and self.fix_x_star == True): # Fixing x_star
+                  and (self.use_numbers_solver == False or self.fix_x_star == True)): # Fixing x_star
                 # Scenario 3: There is an empty site in 
                 # the rate equation but there is no adsorbate term
                 multiplier = sites.count(d_site)
@@ -438,7 +438,7 @@ class MeanFieldSolver(SolverBase):
                         [ads_str]*(ads_mult-1))+ ')'
                 rate_string += '*'+mult_rule
 
-            elif self.fix_x_star == False:
+            elif (self.use_numbers_solver == True and self.fix_x_star == False):
                 # Scenario 5: If x_star is not fixed, then 
                 # the partial derivatives are to be taken 
                 # independently for each site and adsorbate   

--- a/catmap/solvers/numbers_solver.py
+++ b/catmap/solvers/numbers_solver.py
@@ -21,7 +21,7 @@ class BaseNumbersSolver(abc.ABC):
 
 class ExponentialNumbersToTheta(BaseNumbersSolver):
     """Converts the numbers to theta using an exponential numbers to theta conversion
-    
+
     This conversion comes from the following equation:
     .. math::
         \\theta_i = \\frac{e^{x_i}}{\\sum_{j \\in S_i} e^{x_j}}
@@ -42,7 +42,7 @@ class ExponentialNumbersToTheta(BaseNumbersSolver):
         The conversion is done using the following equation:
         .. math::
             \\theta_i = \\frac{e^{x_i}}{\\sum_{j \\in S_i} e^{x_j}}
-        
+
         Parameters
         ----------
         x_including_surface : list
@@ -98,7 +98,7 @@ class ExponentialNumbersToTheta(BaseNumbersSolver):
         equation:
         .. math::
             \\\frac{d\\theta_i}{dx_k} = \\frac{e^{x_i}}{\\sum_{j \\in S_i} e^{x_j}} \\delta_{ik} - \\frac{e^{x_i + x_k}}{\\left(\\sum_{j \\in S_i} e^{x_j}\\right)^2
-        
+
         Parameters
         ----------
         x_including_surface : list
@@ -141,7 +141,7 @@ class ExponentialNumbersToTheta(BaseNumbersSolver):
 
 class SquaredNumbersToTheta(BaseNumbersSolver):
     """Converts the numbers to theta using a squared numbers to theta conversion
-    
+
     This conversion comes from the following equation:
     .. math::
         \\theta_i = \\frac{x_i^2}{\\sum_{j \\in S_i} x_j^2}
@@ -158,11 +158,11 @@ class SquaredNumbersToTheta(BaseNumbersSolver):
         math_obj=None,
     ):
         """Converts the numbers to theta
-        
+
         The conversion is done using the following equation:
         .. math::
             \\theta_i = \\frac{x_i^2}{\\sum_{j \\in S_i} x_j^2}
-        
+
         Parameters
         ----------
         x_including_surface : list
@@ -212,13 +212,13 @@ class SquaredNumbersToTheta(BaseNumbersSolver):
         mpfloat=None,
     ):
         """Returns the conversion matrix for the numbers to theta conversion
-        
+
         This matrix is useful for converting the Jacobian from the coverages
         basis to the numbers basis. The conversion is done using the following
         equation:
         .. math::
             \\\frac{d\\theta_i}{dx_k} = \\frac{2x_i}{\\sum_{j \\in S_i} x_j^2} \\delta_{ik} - \\frac{2x_i^2}{\\left(\\sum_{j \\in S_i} x_j^2\\right)^2}
-        
+
         Parameters
         ----------
         x_including_surface : list
@@ -268,7 +268,7 @@ def debug_writer(filename, writeout):
 
 def get_theta_converter(numbers_type):
     """Returns the theta converter based on the numbers_type
-    
+
     Parameters
     ----------
     numbers_type : str
@@ -287,9 +287,9 @@ Unknown type of numbers_type, use either squared or exponential."""
 
 class SteadyStateNumbersSolver:
     """Steady State Numbers solvers to solve the steady state equations
-    
+
     This class is used to solve the steady state equations for the numbers
-    solver. The steady state equations are solved using a Newton-Raphson 
+    solver. The steady state equations are solved using a Newton-Raphson
     method implemented in :meth:`catmap.solvers.solver_base.NewtonRootNumbers`.
 
     Parameters
@@ -308,7 +308,7 @@ class SteadyStateNumbersSolver:
 
     def change_x_to_theta(self, x):
         """A generic change_x_to_theta function which is needed for all bisections.
-        
+
         This method is a wrapper around the output of the change_x_to_theta method in
         the get_theta_converter function (which return a class based on inputs).
 
@@ -316,11 +316,11 @@ class SteadyStateNumbersSolver:
         ------
         x: List
             Numbers
-        
+
         Returns
         -------
         theta: List
-            Coverages based on the numbers        
+            Coverages based on the numbers
         """
         totheta = get_theta_converter(self.numbers_type)
         _change_x_to_theta = lambda x: totheta.change_x_to_theta(

--- a/catmap/solvers/solver_base.py
+++ b/catmap/solvers/solver_base.py
@@ -9,20 +9,20 @@ import logging
 class SolverBase(ReactionModelWrapper):
     def __init__(self,reaction_model=None):
         """
-        Class for `solving' for equilibrium coverages and rates as a 
-        function of reaction parameters. This class acts as a base class 
-        to be inherited by other solver classes, but is not 
-        functional on its own. 
+        Class for `solving' for equilibrium coverages and rates as a
+        function of reaction parameters. This class acts as a base class
+        to be inherited by other solver classes, but is not
+        functional on its own.
 
-        rxn_parameters: list of necessary parameters to solve the kinetic 
+        rxn_parameters: list of necessary parameters to solve the kinetic
         system. This will usually be populated by the scaler.
 
         A functional derived solver class must also contain the methods:
 
-        get_coverage(): a function which returns coverages for each 
+        get_coverage(): a function which returns coverages for each
             adsorbate as a list [cvg_ads1,cvg_ads2,...]
 
-        get_rate(): a function which returns steady-state reaction 
+        get_rate(): a function which returns steady-state reaction
             rates for each elementary step as a list [rate_rxn1,rate_rxn2,...]
 
         get_residual(): a function for computing the norm of the residual. This
@@ -41,18 +41,18 @@ class SolverBase(ReactionModelWrapper):
         :param rxn_parameters: Reaction parameters.
         :type rxn_parameters: list
         """
-        if True in [v in self.mapper._solver_output 
+        if True in [v in self.mapper._solver_output
                 for v in self.output_variables]:
             cvgs = self._coverage
             # If the numbers solver is being used
-            # make sure to pass along the numbers and not 
+            # make sure to pass along the numbers and not
             # the coverage as an initial guess
             if self.use_numbers_solver:
                 numbers = self._numbers
-                self._coverage = list(self.solver.get_coverage( 
+                self._coverage = list(self.solver.get_coverage(
                         rxn_parameters,c0=numbers)) #verify coverage
             else:
-                self._coverage = list(self.solver.get_coverage( 
+                self._coverage = list(self.solver.get_coverage(
                         rxn_parameters,c0=cvgs)) #verify coverage
 
             self._rate = list(self.solver.get_rate(rxn_parameters,
@@ -66,7 +66,7 @@ class SolverBase(ReactionModelWrapper):
 
             self._turnover_frequency = self.get_turnover_frequency(
                     rxn_parameters)
-        
+
         if 'selectivity' in self.output_variables:
             self._selectivity = self.get_selectivity(rxn_parameters)
             self.output_labels['selectivity'] = self.gas_names
@@ -114,23 +114,23 @@ class SolverBase(ReactionModelWrapper):
 
         for out in self.output_variables:
             if out == 'production_rate':
-                self._production_rate = [max(0,r) 
+                self._production_rate = [max(0,r)
                         for r in self._turnover_frequency]
                 self.output_labels['production_rate'] = self.gas_names
             if out == 'consumption_rate':
-                self._consumption_rate = [max(0,-r) 
+                self._consumption_rate = [max(0,-r)
                         for r in self._turnover_frequency]
                 self.output_labels['consumption_rate'] = self.gas_names
             if out == 'forward_rate':
-                self._forward_rate = [max(0,r) 
+                self._forward_rate = [max(0,r)
                         for r in self._rate]
                 self.output_labels['forward_rate'] = self.elementary_rxns
             if out == 'reverse_rate':
-                self._reverse_rate = [max(0,-r) 
+                self._reverse_rate = [max(0,-r)
                         for r in self._rate]
                 self.output_labels['reverse_rate'] = self.elementary_rxns
             if out == 'rxn_direction':
-                self._rxn_direction = [np.sign(r) 
+                self._rxn_direction = [np.sign(r)
                         for r in self._turnover_frequency]
                 self.output_labels['rxn_direction'] = self.elementary_rxns
             if out == 'rate_constant':
@@ -143,7 +143,7 @@ class SolverBase(ReactionModelWrapper):
                 self._reverse_rate_constant = list(self._kr)
                 self.output_labels['reverse_rate_constant'] = self.elementary_rxns
             if out == 'equilibrium_constant':
-                self._equilibrium_constant = [kf/kr 
+                self._equilibrium_constant = [kf/kr
                         for kf,kr in zip(self._kf,self._kr)]
                 self.output_labels['equilibrium_constant'] = self.elementary_rxns
 
@@ -290,7 +290,7 @@ class ODESolver:
         self._mpfloat = mpfloat
         self.f = f
         self.x0 = x0
-        tol = kwargs.get('tol', self._mpfloat('1e-1')) 
+        tol = kwargs.get('tol', self._mpfloat('1e-1'))
         self.dt = kwargs.get('dt', self._mpfloat('1e-15'))
         self.t0 = kwargs.get('t0', self._mpfloat('0.0'))
 
@@ -308,7 +308,7 @@ class ODESolver:
 
 class NewtonRootNumbers:
     """
-    Hacked from MDNewton in mpmath/calculus/optimization.py to 
+    Hacked from MDNewton in mpmath/calculus/optimization.py to
     implement the numbers solver method.
 
     Find the root of a vector function numerically using Newton's method.
@@ -322,14 +322,14 @@ class NewtonRootNumbers:
     """
 
     def __init__(self, f, x0, math, matrix, mpfloat, Axb_solver, **kwargs):
-        # Store an inner log file and get what to store 
+        # Store an inner log file and get what to store
         self.verbose = kwargs['verbose']
 
         # Get the information about how the math should be handled
         self._math = math
         self._matrix = matrix
         self._mpfloat = mpfloat
-        
+
         # Solver for the inner optimization problem
         self._Axb = Axb_solver
 
@@ -345,13 +345,13 @@ class NewtonRootNumbers:
         if "rcond" in kwargs:
             self.rcond = kwargs['rcond']
         else:
-            self.rcond = None 
+            self.rcond = None
 
         # Decide if the Jacobian should be checked
         if kwargs['DEBUG']:
             # The Jacobian is checked based on the numerical Jacobian
             # determined by finite differences at the same point
-            self.check_jacobian = True 
+            self.check_jacobian = True
             self.DEBUG = True
         else:
             # If not debugging, then don't check the Jacobian
@@ -371,8 +371,8 @@ class NewtonRootNumbers:
         self.norm = kwargs['norm']
         self.max_damping = kwargs['max_damping']
 
-        # conversion from coverages to numbers and conversion 
-        # dtheta/dx matrix to get the Jacobian matrix 
+        # conversion from coverages to numbers and conversion
+        # dtheta/dx matrix to get the Jacobian matrix
         self.conversion_function = kwargs['conversion_function']
         self.dtheta_dx_function = kwargs['dtheta_dx_function']
 
@@ -399,7 +399,7 @@ class NewtonRootNumbers:
         # Get the analytical Jacobian
         analytical = self.J_analytical(theta)
         # Get the numerical Jacobian
-        numerical = self.J_numerical(theta) 
+        numerical = self.J_numerical(theta)
         # Compare the analytical and numerical Jacobian
         error = analytical - numerical
         if self.fix_x_star:
@@ -428,7 +428,7 @@ class NewtonRootNumbers:
         if rcond:
             cutoff = rcond * mp.fabs(S[0])
         else:
-            cutoff = self.precision        
+            cutoff = self.precision
 
         # Take the inverse of S
         S_inv = []
@@ -441,7 +441,7 @@ class NewtonRootNumbers:
         # S is a diagonal matrix
         S_plus = self._math.diag(S_inv)
 
-        # Take the pseudo-inverse of M 
+        # Take the pseudo-inverse of M
         M_plus = V.T * S_plus * U.T
 
         return M_plus
@@ -450,12 +450,12 @@ class NewtonRootNumbers:
         # There are two possible routines for finding the root
         # through the multi-dimensional Newton method.
         # The first is to consider all x as independent variables
-        # The second is to consider x_star = 1 and change the other 
+        # The second is to consider x_star = 1 and change the other
         if not self.fix_x_star:
-            # Note that this is the objective function 
+            # Note that this is the objective function
             # That still depends on theta
             f = self.f
-            # The Jacobian which depends on coverage 
+            # The Jacobian which depends on coverage
             J = self.J
             # matrix to get_dtheta_dx
             dtheta_dx_function = lambda x: self.dtheta_dx_function(list(x))
@@ -498,10 +498,10 @@ class NewtonRootNumbers:
                     # Ensure that the sum of fx is 0
                     assert mp.fabs(mp.fsum(fx)) < self.precision, "fx is not zero"
 
-                # Check if the objective function is the 
-                # same length as theta 
+                # Check if the objective function is the
+                # same length as theta
                 assert fx.rows == len(theta)
-            
+
             if self.fix_x_star:
                 assert fx.rows == len(theta) - self.esites
 
@@ -538,8 +538,8 @@ class NewtonRootNumbers:
 
             if self.DEBUG:
                 if not self.fix_x_star:
-                    # The sum over all columns of the Jacobian 
-                    # matrix must be 0. This is because the term would be 
+                    # The sum over all columns of the Jacobian
+                    # matrix must be 0. This is because the term would be
                     # d/dtheta_i (sum_i f_i)
                     # where sum_i f_i = 0
                     for i in range(Jtheta.cols):
@@ -576,17 +576,17 @@ class NewtonRootNumbers:
                 s = self._matrix(s)
 
             else:
-                # Since we are not fixing x_star, we are 
+                # Since we are not fixing x_star, we are
                 # solving an unconstrained problem, with more
                 # variables than equations, so we need to use
                 # a least-squares method, which starts with
                 # taking the Moore-Penrose inverse of Jx
                 # The conditioning number rcond is 10^5 times
                 # the machine precision
-                prec = -1*int(mp.log10(self.precision)/2) 
+                prec = -1*int(mp.log10(self.precision)/2)
                 rcond = self._mpfloat(f'1e{prec}') * self.precision
                 Jx_plus = self.moore_penrose_inverse(M=Jx, rcond=self.rcond)
-                s = Jx_plus * fxn 
+                s = Jx_plus * fxn
 
             # damping step size
             l = self._mpfloat('1.0')

--- a/catmap/solvers/steady_state_solver.py
+++ b/catmap/solvers/steady_state_solver.py
@@ -98,7 +98,7 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
             raise ValueError("No initial coverage supplied. Mapper must supply initial guess")
 
         self.steady_state_function = steady_state_fn
-        self.steady_state_jacobian = None 
+        self.steady_state_jacobian = None
         self._coverage = [self._mpfloat(ci) for ci in c0]
         self._rxn_parameters = rxn_parameters
 
@@ -106,7 +106,7 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
         norm = self._math.infnorm
         norm_lsqnorm = self._math.lsqnorm
 
-        solver = ODESolver  
+        solver = ODESolver
 
         iterations = solver(f,c0, self._matrix, self._mpfloat)
         i = 0
@@ -127,7 +127,7 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
                             n_iter=i,
                             resid = float(residual))
                     raise ValueError('Out of iterations (resid='+\
-                            str(float(residual))+')') 
+                            str(float(residual))+')')
 
     def get_steady_state_coverage(self,rxn_parameters,steady_state_fn, jacobian_fn,
             c0=None,findrootArgs={}):
@@ -372,12 +372,12 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
             if self.use_numbers_solver:
                 # no need to include empty coverage as possible guess
                 # As the Jacobian for such a guess will be singular
-                # sites = len(self.site_names) - 1 
-                # boltz_cvgs = [[self._mpfloat('0.0')]*len(self.adsorbate_names) + [self._mpfloat('1.0')]*sites] 
+                # sites = len(self.site_names) - 1
+                # boltz_cvgs = [[self._mpfloat('0.0')]*len(self.adsorbate_names) + [self._mpfloat('1.0')]*sites]
                 boltz_cvgs = []
             else:
                 #include empty coverage as possible guess
-                boltz_cvgs = [[self._mpfloat('0.0')]*len(self.adsorbate_names)] 
+                boltz_cvgs = [[self._mpfloat('0.0')]*len(self.adsorbate_names)]
 
             for ref_dict in self.atomic_reservoir_list:
                 self.atomic_reservoir_dict = ref_dict
@@ -386,14 +386,14 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
                 else:
                     cvgs = self.thermodynamics.boltzmann_coverages(energy_dict)
                 boltz_cvgs.append(cvgs)
-            
+
 
         else:
             if self.use_numbers_solver:
                 boltz_cvgs = [self.thermodynamics.boltzmann_numbers(energy_dict)]
             else:
                 boltz_cvgs = [self.thermodynamics.boltzmann_coverages(energy_dict)]
-            
+
 
         return boltz_cvgs
 
@@ -511,14 +511,14 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
             if self.DEBUG:
                 with open('steady_state_equations.log', 'w') as handle:
                     handle.write('\n'.join(ss_eqs))
-            # If we are using the numbers solver, the length of the 
-            # steady state function needs to be one more than that of the 
+            # If we are using the numbers solver, the length of the
+            # steady state function needs to be one more than that of the
             # number of adsorbates.
             if self.use_numbers_solver:
                 # Determine the length of the surface based on the number of
                 # adsorbates and sites. Current implementation has the 'g' as a
                 # site, and that should not be included in the numbers solver.
-                # Hence the total number of theta's to solver for is 
+                # Hence the total number of theta's to solver for is
                 # the number of adsorbate + sites -1 (to account for the 'g' site)
                 self._function_substitutions['theta_length'] = len(self.adsorbate_names) + len(self.site_names) - 1
                 self._function_substitutions['number_of_adsorbates'] = len(self.adsorbate_names)

--- a/catmap/solvers/steady_state_solver.py
+++ b/catmap/solvers/steady_state_solver.py
@@ -410,9 +410,11 @@ class SteadyStateSolver(MeanFieldSolver, SteadyStateNumbersSolver):
             self._rxn_parameters = self.scaler.get_rxn_parameters(
                     self._descriptors)
             self.get_rate_constants(self._rxn_parameters,coverages)
-#        cvg_rates = self.steady_state_function(None)
         cvg_rates = self.steady_state_function(coverages)
-        residual = max([abs(r) for r in cvg_rates])
+        if self.use_numbers_solver:
+            residual = self._math.lsqnorm(cvg_rates)
+        else:
+            residual = max([abs(r) for r in cvg_rates])
         return residual
 
 

--- a/catmap/thermodynamics/enthalpy_entropy.py
+++ b/catmap/thermodynamics/enthalpy_entropy.py
@@ -24,7 +24,7 @@ class ThermoCorrections(ReactionModelWrapper):
     The function "get_thermodynamic_corrections" automatically does all the work
     assuming the correct functions are in place.
 
-    thermodynamic_corrections: List of fundamentally different types of 
+    thermodynamic_corrections: List of fundamentally different types of
         corrections which could be included. Defaults are gas and adsorbate
         but other possibilities might be interface, electrochemical, etc.
 
@@ -39,7 +39,7 @@ class ThermoCorrections(ReactionModelWrapper):
         2) Place the "custom_correction" in the "thermodynamic_corrections" list
         3) Place any variables which the custom correction depends on in
             the thermodynamic_variables list
-        4) Set the "custom_correction_thermo_mode" attribute of the 
+        4) Set the "custom_correction_thermo_mode" attribute of the
             underlying reaction model to "simple_custom_correction"
 
     If these steps are followed then the correction should automatically be
@@ -84,12 +84,12 @@ class ThermoCorrections(ReactionModelWrapper):
         self._required = {'thermodynamic_corrections':list,
                 'thermodynamic_variables':list,
                 }
-                
+
         self._zpe_dict = {}
         self._enthalpy_dict = {}
         self._entropy_dict = {}
         self._rxm.update(defaults)
-                
+
         for corr in self.thermodynamic_corrections:
             self._required[corr+'_thermo_mode'] = str
             self.thermodynamic_variables.append(corr+'_thermo_mode')
@@ -109,7 +109,7 @@ class ThermoCorrections(ReactionModelWrapper):
         for key in kwargs:
             if key in state_dict:
                 state_dict[key] = kwargs[key]
-        current_state = [repr(state_dict[v]) 
+        current_state = [repr(state_dict[v])
                 for v in self.thermodynamic_variables]
 
         for sp in self.species_definitions:
@@ -118,10 +118,10 @@ class ThermoCorrections(ReactionModelWrapper):
         frequency_dict = self.frequency_dict.copy()
 
         if (
-                getattr(self,'_current_state',None) == current_state and 
+                getattr(self,'_current_state',None) == current_state and
                 getattr(self,'_frequency_dict',None) == frequency_dict and
                 not self.force_recalculation
-                ): #if the thermodynamic state (and frequencies) 
+                ): #if the thermodynamic state (and frequencies)
             #has not changed then don't bother re-calculating the corrections.
             return self._correction_dict
 
@@ -131,7 +131,7 @@ class ThermoCorrections(ReactionModelWrapper):
         self._frequency_dict = frequency_dict
 
         self.kBT = self._kB*self.temperature
-        
+
         # apply corrections in self.thermodynamic_corrections on top of each other
         for correction in self.thermodynamic_corrections:
             mode = getattr(self,correction+'_thermo_mode')
@@ -140,7 +140,7 @@ class ThermoCorrections(ReactionModelWrapper):
 
         if self.pressure_mode:
             getattr(self,self.pressure_mode+'_pressure')()
-            
+
         #if hasattr(self,'equilibrated') and self.equilibrated:
         #    self.set_equilibrated()
 
@@ -184,24 +184,24 @@ class ThermoCorrections(ReactionModelWrapper):
         return correction_dict
 
     def ideal_gas(self):
-        """Calculate the thermal correction to the free energy of 
-        an ideal gas using the IdealGasThermo class in ase.thermochemistry 
+        """Calculate the thermal correction to the free energy of
+        an ideal gas using the IdealGasThermo class in ase.thermochemistry
         along with the molecular structures in ase.data.molecules.
 
-        gas_names = the chemical formulas of the gasses of interest (usually 
+        gas_names = the chemical formulas of the gasses of interest (usually
             ending in _g to denote that they are in the gas phase).
-        freq_dict = dictionary of vibrational frequencies for each gas 
-            of interest. Vibrational frequencies should be in eV. 
-            The dictionary should be of the form 
+        freq_dict = dictionary of vibrational frequencies for each gas
+            of interest. Vibrational frequencies should be in eV.
+            The dictionary should be of the form
             freq_dict[gas_name] = [freq1, freq2, ...]
-        ideal_gas_params = dictionary of the symmetry number, 
-            geometry keyword, and spin of the gas. If no dictionary 
-            is specified then the function will attempt to look the 
-            gas up in the hard-coded gas_params dictionary. 
-            The dictionary should be of the form 
+        ideal_gas_params = dictionary of the symmetry number,
+            geometry keyword, and spin of the gas. If no dictionary
+            is specified then the function will attempt to look the
+            gas up in the hard-coded gas_params dictionary.
+            The dictionary should be of the form
             ideal_gas_params[gas_name] = [symmetry_number, geometry, spin]
-        atoms_dict = dictionary of ase atoms objects to use for 
-            calculating rotational contributions. If none is specified 
+        atoms_dict = dictionary of ase atoms objects to use for
+            calculating rotational contributions. If none is specified
             then the function will look in ase.data.molecules.
 
         """
@@ -243,14 +243,14 @@ class ThermoCorrections(ReactionModelWrapper):
             gpars = gas_param_dict[gas]
             symmetry,geometry,spin = gpars[:3]
             fugacity = self._bar2Pa
-            #Pressures should not be used in microkinetic 
-            #modelling; they are implicitly included in the 
+            #Pressures should not be used in microkinetic
+            #modelling; they are implicitly included in the
             #rate expressions via the thermodynamic derivations.
 
             atoms = atoms_dict[gas]
             therm = IdealGasThermo(
-                    freq_dict[gas], geometry, 
-                    atoms=atoms, symmetrynumber=symmetry, 
+                    freq_dict[gas], geometry,
+                    atoms=atoms, symmetrynumber=symmetry,
                     spin=spin)
 
             ZPE = 0.5*(sum(freq_dict[gas]))
@@ -259,7 +259,7 @@ class ThermoCorrections(ReactionModelWrapper):
             S = therm.get_entropy(temperature, fugacity, verbose=False)
 
             free_energy = H-temperature*S
-            thermo_dict[gas] = free_energy #use thermodynamic state 
+            thermo_dict[gas] = free_energy #use thermodynamic state
                     #from ase.thermochemistry to calculate thermal corrections.
             self._zpe_dict[gas] = ZPE
             self._enthalpy_dict[gas] = H
@@ -275,7 +275,7 @@ class ThermoCorrections(ReactionModelWrapper):
         temperature = float(self.temperature)
 
         # added to avoid unnecessary inner loop ahead
-        shomate_params = {}        
+        shomate_params = {}
         for _ in self.shomate_params.keys():
             _n = _.split(':')[0].replace('*','')
             T_min, T_max = sorted([float(__) for __ in _.split(':')[1].split('-')])
@@ -283,7 +283,7 @@ class ThermoCorrections(ReactionModelWrapper):
                 shomate_params[_n] += [{'params':self.shomate_params[_],'T_min':T_min,'T_max':T_max}]
             else:
                 shomate_params[_n] = [{'params':self.shomate_params[_],'T_min':T_min,'T_max':T_max}]
-                
+
         thermo_dict = {}
         not_there = []
         for gas in gas_names:
@@ -300,8 +300,8 @@ class ThermoCorrections(ReactionModelWrapper):
                         self.log('shomate_warning_gas',gas=gas,T=params['T_min'])
                     else:
                         raise Exception('Logical error.')
-                    ZPE = sum(self.frequency_dict[gas])/2.0     
-                    free_energy = ZPE +  dH - temperature*dS 
+                    ZPE = sum(self.frequency_dict[gas])/2.0
+                    free_energy = ZPE +  dH - temperature*dS
                     self._zpe_dict[gas] = ZPE
                     self._enthalpy_dict[gas] = dH
                     self._entropy_dict[gas] = dS
@@ -319,7 +319,7 @@ class ThermoCorrections(ReactionModelWrapper):
 
     def fixed_entropy_gas(self,include_ZPE=True):
         """
-        Add entropy based on fixed_entropy_dict (entropy contribution to free 
+        Add entropy based on fixed_entropy_dict (entropy contribution to free
         energy assumed linear with temperature) and ZPE
         """
         thermo_dict = {}
@@ -403,13 +403,13 @@ class ThermoCorrections(ReactionModelWrapper):
         return thermo_dict
 
     def harmonic_adsorbate(self):
-        """Calculate the thermal correction to the free energy of 
-        an adsorbate in the harmonic approximation using the HarmonicThermo 
+        """Calculate the thermal correction to the free energy of
+        an adsorbate in the harmonic approximation using the HarmonicThermo
         class in ase.thermochemistry.
 
         adsorbate_names = the chemical formulas of the adsorbates of interest.
-        freq_dict = dictionary of vibrational frequencies for each adsorbate of 
-            interest. Vibrational frequencies should be in eV. The dictionary 
+        freq_dict = dictionary of vibrational frequencies for each adsorbate of
+            interest. Vibrational frequencies should be in eV. The dictionary
             should be of the form freq_dict[ads_name] = [freq1, freq2, ...]
         """
         adsorbate_names = self.adsorbate_names+self.transition_state_names
@@ -451,13 +451,13 @@ class ThermoCorrections(ReactionModelWrapper):
                                    'Update your ASE version.')
                     free_energy = therm.get_free_energy(
                             temperature,verbose=False)
-                ZPE = sum(frequencies)/2.0 
+                ZPE = sum(frequencies)/2.0
                 dS = therm.get_entropy(temperature,verbose=False)
                 dH = therm.get_internal_energy(temperature,verbose=False) - ZPE
                 self._zpe_dict[ads] = ZPE
                 self._enthalpy_dict[ads] = dH
                 self._entropy_dict[ads] = dS
-                thermo_dict[ads] = free_energy #use thermodynamic state from 
+                thermo_dict[ads] = free_energy #use thermodynamic state from
                 #ase.thermochemistry to calculate thermal corrections.
             elif '-' in ads:
                 avg_TS.append(ads)
@@ -468,7 +468,7 @@ class ThermoCorrections(ReactionModelWrapper):
         thermo_dict.update(ts_thermo)
 
         return thermo_dict
-    
+
     def _shomate_eq(self,params,temperature=[]):
         if not temperature:
             temperature = self.temperature
@@ -476,7 +476,7 @@ class ThermoCorrections(ReactionModelWrapper):
         def H(T,params):
             A,B,C,D,E,F,G,H = params
             t = T/1000.0
-            H = A*t + (B/2.0)*t**2 + (C/3.0)*t**3 + (D/4.0)*t**4 - E/t + F - H 
+            H = A*t + (B/2.0)*t**2 + (C/3.0)*t**3 + (D/4.0)*t**4 - E/t + F - H
             #kJ/mol
             return H
 
@@ -492,30 +492,30 @@ class ThermoCorrections(ReactionModelWrapper):
             t = T/1000.0
             Cp = A + B*t + C*t**2 + D*t**3 +E/(t**2)
             return Cp
-        
+
         dH = H(temperature,params) - H(temperature_ref,params)
         dS = S(temperature,params)
         Cp_ref = Cp(temperature_ref,params)
         dH = (temperature_ref*Cp_ref/1000.0 + dH)*(self._kJmol2eV) #eV
         dS = dS*(self._kJmol2eV/1e3) #eV/K
         return dH, dS, Cp_ref
-    
+
     def shomate_adsorbate(self):
         """Calculate the thermal correction to the free energy of an
-        adsorbate using pre-fitted shomate parameters.        
+        adsorbate using pre-fitted shomate parameters.
         """
-        
+
         adsorbate_names = self.adsorbate_names+self.transition_state_names
         temperature = float(self.temperature)
-        
+
         thermo_dict = {}
         if temperature == 0: temperature = 1e-99
 
         avg_TS = []
         self._freq_cutoffs = {}
-        
+
         # added to avoid unnecessary inner loop ahead
-        shomate_params = {}        
+        shomate_params = {}
         for _ in self.shomate_params.keys():
             _n = _.split(':')[0].replace('*','')
             T_min, T_max = sorted([float(__) for __ in _.split(':')[1].split('-')])
@@ -523,7 +523,7 @@ class ThermoCorrections(ReactionModelWrapper):
                 shomate_params[_n] += [{'params':self.shomate_params[_],'T_min':T_min,'T_max':T_max}]
             else:
                 shomate_params[_n] = [{'params':self.shomate_params[_],'T_min':T_min,'T_max':T_max}]
-        
+
         def _thermo(params):
             if (temperature >= params['T_min'] and temperature <= params['T_max']):
                 dH, dS, Cp_ref = self._shomate_eq(params['params'])
@@ -533,7 +533,7 @@ class ThermoCorrections(ReactionModelWrapper):
             else:
                 raise Exception('Logical error.')
             return dH, dS, Cp_ref
-        
+
         for ads in adsorbate_names:
             # this will also work for TS if shomate parameters are available.
             if ads in shomate_params:
@@ -542,7 +542,7 @@ class ThermoCorrections(ReactionModelWrapper):
                              (temperature<params[_]['T_min'] and params[_]['T_min']<300)) else None for _ in range(len(params))]))
                 if len(loc) > 0:
                     if self.frequency_dict[ads]:
-                        ZPE = sum(self.frequency_dict[ads])/2.0 
+                        ZPE = sum(self.frequency_dict[ads])/2.0
                         self._zpe_dict[ads] = ZPE
                     else:
                         self.average_transition_state(thermo_dict,transition_state_list = [ads], thermo_vars = [self._zpe_dict])
@@ -551,7 +551,7 @@ class ThermoCorrections(ReactionModelWrapper):
                     dH, dS, Cp_ref = _thermo(params)
                     self._enthalpy_dict[ads] = dH
                     self._entropy_dict[ads] = dS
-                    free_energy = ZPE +  dH - temperature*dS 
+                    free_energy = ZPE +  dH - temperature*dS
                     thermo_dict[ads] = free_energy
                 else:
                     raise ValueError('No Shomate parameters available for T = {}  specified for {}'.format(temperature,ads))
@@ -562,43 +562,43 @@ class ThermoCorrections(ReactionModelWrapper):
         ts_thermo = self.average_transition_state(thermo_dict,avg_TS)
         thermo_dict.update(ts_thermo)
         return thermo_dict
-    
+
     def hindered_adsorbate(self):
-        """Calculate the thermal correction to the free energy of an 
-        adsorbate in the hindered translator and hindered rotor model using 
-        the HinderedThermo class in ase.thermochemistry along with the 
-        molecular structures in ase.data.molecules. Requires ase version 
+        """Calculate the thermal correction to the free energy of an
+        adsorbate in the hindered translator and hindered rotor model using
+        the HinderedThermo class in ase.thermochemistry along with the
+        molecular structures in ase.data.molecules. Requires ase version
         3.12.0 or greater.
 
-        adsorbate_names = the chemical formulas of the adsorbates of interest. 
-        freq_dict = dictionary of vibrational frequencies for each adsorbate of 
-            interest. Vibrational frequencies should be in eV. The dictionary 
+        adsorbate_names = the chemical formulas of the adsorbates of interest.
+        freq_dict = dictionary of vibrational frequencies for each adsorbate of
+            interest. Vibrational frequencies should be in eV. The dictionary
             should be of the form freq_dict[ads_name] = [freq1, freq2, ...]
-        hindered_ads_params = dictionary containing for each adsorbate 
-            [0] = translational energy barrier in eV (barrier for the 
+        hindered_ads_params = dictionary containing for each adsorbate
+            [0] = translational energy barrier in eV (barrier for the
                   adsorbate to diffuse on the surface)
-            [1] = rotational energy barrier in eV (barrier for the adsorbate 
+            [1] = rotational energy barrier in eV (barrier for the adsorbate
                   to rotate about an axis perpendicular to the surface)
-            [2] = surface site density in cm^-2 
-            [3] = number of equivalent minima in full adsorbate rotation 
-            [4] = mass of the adsorbate in amu (can be unspecified by putting 
-                  None, in which case mass will attempt to be calculated from 
+            [2] = surface site density in cm^-2
+            [3] = number of equivalent minima in full adsorbate rotation
+            [4] = mass of the adsorbate in amu (can be unspecified by putting
+                  None, in which case mass will attempt to be calculated from
                   the ase atoms class)
-            [5] = reduced moment of inertia of the adsorbate in amu*Ang^-2 
-                  (can be unspecified by putting None, in which case inertia 
+            [5] = reduced moment of inertia of the adsorbate in amu*Ang^-2
+                  (can be unspecified by putting None, in which case inertia
                   will attempt to be calculated from the ase atoms class)
-            [6] = symmetry number of the adsorbate (number of symmetric arms 
-                  of the adsorbate which depends upon how it is bound to the 
-                  surface. For example, propane bound through its end carbon 
-                  has a symmetry number of 1 but propane bound through its 
-                  middle carbon has a symmetry number of 2. For single atom 
+            [6] = symmetry number of the adsorbate (number of symmetric arms
+                  of the adsorbate which depends upon how it is bound to the
+                  surface. For example, propane bound through its end carbon
+                  has a symmetry number of 1 but propane bound through its
+                  middle carbon has a symmetry number of 2. For single atom
                   adsorbates such as O* the symmetry number is 1.)
-            The dictionary should be of the form 
-            hindered_ads_params[ads_name] = [barrierT, barrierR, site_density, 
+            The dictionary should be of the form
+            hindered_ads_params[ads_name] = [barrierT, barrierR, site_density,
             rotational_minima, mass, inertia, symmetry_number]
-        atoms_dict = dictionary of ase atoms objects to use for calculating 
-            mass and rotational inertia. If none is specified then the function 
-            will look in ase.data.molecules. Can be omitted if both mass and 
+        atoms_dict = dictionary of ase atoms objects to use for calculating
+            mass and rotational inertia. If none is specified then the function
+            will look in ase.data.molecules. Can be omitted if both mass and
             rotational inertia are specified in hindered_ads_params.
 
         """
@@ -625,7 +625,7 @@ class ThermoCorrections(ReactionModelWrapper):
         self._freq_cutoffs = {}
 
         for ads in adsorbate_names:
-            if '-' in ads and (freq_dict[ads] in [None,[],()] or 
+            if '-' in ads and (freq_dict[ads] in [None,[],()] or
                     ads not in ads_param_dict):
                 avg_TS.append(ads)
                 break
@@ -671,8 +671,8 @@ class ThermoCorrections(ReactionModelWrapper):
                     raise IndexError('Missing either mass and inertia of '+ads+
                                      ' or atoms object for '+ads)
             therm = HinderedThermo(
-                    frequencies, barrierT, barrierR, sitedensity, 
-                    rotationalminima, mass=mass, inertia=inertia, 
+                    frequencies, barrierT, barrierR, sitedensity,
+                    rotationalminima, mass=mass, inertia=inertia,
                     atoms=atoms, symmetrynumber=symmetrynumber)
 
             free_energy = therm.get_helmholtz_energy(
@@ -683,7 +683,7 @@ class ThermoCorrections(ReactionModelWrapper):
             self._zpe_dict[ads] = ZPE
             self._enthalpy_dict[ads] = dH
             self._entropy_dict[ads] = dS
-            thermo_dict[ads] = free_energy #use thermodynamic state from 
+            thermo_dict[ads] = free_energy #use thermodynamic state from
             #ase.thermochemistry to calculate thermal corrections.
 
         ts_thermo = self.average_transition_state(thermo_dict,avg_TS)
@@ -736,16 +736,16 @@ class ThermoCorrections(ReactionModelWrapper):
 
     def average_transition_state(self,thermo_dict,transition_state_list = [], thermo_vars = []):
         """
-        Return transition state thermochemical corrections as average of IS and FS corrections 
+        Return transition state thermochemical corrections as average of IS and FS corrections
         """
         if transition_state_list is None:
             transition_state_list = self.transition_state_names
 
         def state_thermo(therm_dict,rx,site_defs,rx_id):
             return sum([therm_dict[s] for s in rx[rx_id] if (
-                            s not in site_defs and not 
+                            s not in site_defs and not
                             s.endswith('_g'))])
-        
+
         if thermo_vars:
             if thermo_dict not in thermo_vars:
                 thermo_vars = [thermo_dict] + thermo_vars
@@ -765,7 +765,7 @@ class ThermoCorrections(ReactionModelWrapper):
         return thermo_dict
 
     def generate_echem_TS_energies(self):
-        """ 
+        """
         Give real energies to the fake echem transition states
         """
         echem_TS_names = self.echem_transition_state_names
@@ -803,7 +803,7 @@ class ThermoCorrections(ReactionModelWrapper):
         return thermo_dict
 
     def get_rxn_index_from_TS(self, TS):
-        """ 
+        """
         Take in the name of a transition state and return the reaction index of
         the elementary rxn from which it belongs
         """
@@ -813,7 +813,7 @@ class ThermoCorrections(ReactionModelWrapper):
 
     def simple_electrochemical(self):
         """
-        Calculate electrochemical (potential) corrections to free energy. Transition state energies are corrected by a beta*voltage term.  
+        Calculate electrochemical (potential) corrections to free energy. Transition state energies are corrected by a beta*voltage term.
         """
         thermo_dict = {}
         gas_names = [gas for gas in self.gas_names if gas.split('_')[0] in ['pe', 'ele']]
@@ -970,10 +970,10 @@ class ThermoCorrections(ReactionModelWrapper):
         for site in self.site_names:
             if site not in energy_dict:
                 energy_dict[site] = 0
-            relevant_ads = [a for a in self.adsorbate_names if 
+            relevant_ads = [a for a in self.adsorbate_names if
                     self.species_definitions[a]['site'] == site]
             free_energies = [energy_dict[a] for a in relevant_ads]+[energy_dict[site]]
-            boltz_sum = sum([self._math.exp(-G/(self._kB*self.temperature)) 
+            boltz_sum = sum([self._math.exp(-G/(self._kB*self.temperature))
                 for G in free_energies])
             for ads in relevant_ads:
                 if ads in self.adsorbate_names:
@@ -997,9 +997,9 @@ class ThermoCorrections(ReactionModelWrapper):
 
     def boltzmann_numbers(self,energy_dict):
         """Generates Boltzmann numbers for each site.
-        A Boltzmann number is given by 
+        A Boltzmann number is given by
         x_i =  exp(-G_i/2kT)
-        The factor of two in the denominator is because x_i^2 is 
+        The factor of two in the denominator is because x_i^2 is
         what is used in the coverage expressions and that is what we
         are trying to replicate here.
         """
@@ -1012,12 +1012,12 @@ class ThermoCorrections(ReactionModelWrapper):
             energy_dict = self.convert_formation_energies(
                     energy_dict,reservoirs,comp_dict)[0]
 
-        #calculate numbers 
+        #calculate numbers
         numbers = [0]*len(self.adsorbate_names)
         for site in self.site_names:
             if site not in energy_dict:
                 energy_dict[site] = 0
-            relevant_ads = [a for a in self.adsorbate_names if 
+            relevant_ads = [a for a in self.adsorbate_names if
                     self.species_definitions[a]['site'] == site]
             free_energies = [energy_dict[a] for a in relevant_ads]+[energy_dict[site]]
             for ads in relevant_ads:
@@ -1027,7 +1027,7 @@ class ThermoCorrections(ReactionModelWrapper):
                     if self.species_definitions[site]['type'] not in ['gas']:
                         numbers[i_overall] = self._math.exp(-free_energies[i_rel]/(
                             self._kB*self.temperature*2))
-        # At the end, add 1 to the numbers list because the free site has 
+        # At the end, add 1 to the numbers list because the free site has
         # a coverage of exp(0)
         for site in self.site_names:
             if site != 'g':
@@ -1057,7 +1057,7 @@ class ThermoCorrections(ReactionModelWrapper):
         Note that this function is not well-tested and should be used with caution.
         """
 
-        print('APPROACH TO EQULIBRIUM PRESSURE')   
+        print('APPROACH TO EQULIBRIUM PRESSURE')
         if 'pressure' not in self.thermodynamic_variables:
             self.thermodynamic_variables += ['pressure']
 
@@ -1102,7 +1102,7 @@ class ThermoCorrections(ReactionModelWrapper):
             reactants += rxn[0]
             products += rxn[1]
             gammas.append(gamma_i)
-        
+
         for sp in set(reactants):
             c = self.species_definitions[sp].get('concentration',None)
             if c is None:
@@ -1125,7 +1125,7 @@ class ThermoCorrections(ReactionModelWrapper):
         for gi,gamma_i in zip(global_rxns,gammas):
             set_product_pressures(gi,G_dict,gamma_i,gas_pressures,product_pressures)
 
-        self.gas_pressures = [gas_pressures[gi] for gi in self.gas_names] 
+        self.gas_pressures = [gas_pressures[gi] for gi in self.gas_names]
         print([float(i) for i in self.gas_pressures])
 
     def get_frequency_cutoff(self,kB_multiplier,temperature=None):
@@ -1150,10 +1150,10 @@ class ThermoCorrections(ReactionModelWrapper):
 
     def summary_text(self):
         return ''
-   
+
     ##############################################################
-    ### _equilibrium functions intend to serve as utility      ### 
-    ###  for initial guess estimation routines. (under dev)    ###  
+    ### _equilibrium functions intend to serve as utility      ###
+    ###  for initial guess estimation routines. (under dev)    ###
     ##############################################################
 
     def set_affine_pressure_equilibrium(self,alpha,x0=[]):
@@ -1161,22 +1161,22 @@ class ThermoCorrections(ReactionModelWrapper):
         and that of equilibrium by an alpha factor
         """
         eq_dict = self.get_pressure_equilibrium()
-        xeq = eq_dict['xeq']; 
+        xeq = eq_dict['xeq'];
         if not x0:
             x0 = eq_dict['x0']
         else:
             pass
         xalpha = alpha*np.array(x0)+(1.-alpha)*xeq
         self.gas_pressures = self.pressure*xalpha
-        return xalpha, xeq, x0        
-    
+        return xalpha, xeq, x0
+
     def get_pressure_equilibrium(self,xguess=None,ftol=1e-5):
         # Calaculate Equilirium Conversion
         gas_species = self.gas_names
         sps_dict = self.species_definitions
         n_atoms = max([len(self.species_definitions[_]['composition'].keys()) \
                                 for _ in gas_species])
-        # Create atomic constraints 
+        # Create atomic constraints
         Aeq = np.zeros([n_atoms,len(gas_species)], dtype=np.float128)
         beq = np.zeros(n_atoms,dtype=np.float128)
         x0 = np.zeros(len(gas_species),dtype=np.float128)
@@ -1203,42 +1203,42 @@ class ThermoCorrections(ReactionModelWrapper):
                     sps_dict[sps]['pressure'] > 0:
                         beq[atoms[atom]] += comp[atom]*(sps_dict[sps]['pressure']/self.pressure)#*sps_dict[sps]['pressure']/self.kBT
                         x0[_] = sps_dict[sps]['pressure']/self.pressure
-       
+
         # Optimization section
         from scipy.optimize import minimize, Bounds
-    
+
         # First minimization problem, x should be a molar fraction assuming static pressure
         # Calculate the systems' ultimate equilibrium composition
-        
+
         thermo_corrections = self._correction_dict
         energies = np.array([sps_dict[_]['formation_energy']+thermo_corrections[_] for _ in gas_species],dtype=np.float128)
-        
+
         log0 = lambda x : np.nan_to_num(np.log(x)*(np.isfinite(np.log(x))))
-        
+
         # Objective function
         def total_gibbs(x):
             G0 = np.dot(energies,x)/float(self.kBT)
             Sconf = np.dot(log0(x),x)
             return (G0+Sconf+np.log(self.pressure*sum(x)))
-        
+
         # Jacobian
-        
+
         jac_total_gibbs = lambda x : np.array(energies/float(self.kBT)+np.log(x+1e-300)+np.ones(len(x)),dtype=np.float128)
-        
+
         # Bounds
         bounds = Bounds(*[[0. for _ in range(len(gas_species))],[np.inf for _ in range(len(gas_species))]])
-    
+
         # Equality constraints
         #Aeq[-1,:] = np.array(1.,dtype=np.float128)
         #beq[-1] = np.array(1.,dtype=np.float128)
         eq_cons = {'type': 'eq',
                    'fun' : lambda x: np.dot(Aeq,x)-beq,
                    'jac' : lambda x: Aeq}
-        
+
         ineq_cons = {'type': 'ineq',
                    'fun' : lambda x: x,
                    'jac' : lambda x: np.eye(*np.shape(x))}
-        
+
         xeq = minimize(total_gibbs, xguess if xguess else x0, method='SLSQP', jac=jac_total_gibbs,
                        constraints=[eq_cons,ineq_cons], options={'ftol': ftol, 'disp': False, 'maxiter':1000,'eps': 1.4901161193847656e-08},
                        bounds=bounds)
@@ -1251,9 +1251,9 @@ class ThermoCorrections(ReactionModelWrapper):
             print(Aeq.dot(xeq.x)-beq)
             print(sum(xeq.x))
             raise Exception()
-        
+
         return dict(zip(('xeq','x0','Aeq','beq','feq','G0'),(xeq.x, x0, Aeq, beq, xeq.fun, total_gibbs(x0))))
-    
+
     def set_equilibrated(self):
         """ Set reactants/products as their equilibrium composition a priori
             such that close-to-equilibrium species TOF do not overshadow thos of
@@ -1264,20 +1264,20 @@ class ThermoCorrections(ReactionModelWrapper):
             total pressure.
         """
         print('SET EQUILIBRATED.')
-        
+
         gas_species = self.gas_names
-        
+
         xeq, x0, Aeq, beq, Geq, G0 = self.get_pressure_equilibrium()
-        
+
         # Total Gibbs
         def total_gibbs(x):
             G0 = np.dot(energies,x)/float(self.kBT)
             Sconf = np.dot(log0(x),x)
             return G0+Sconf+np.log(self.pressure)
-        
+
         # Second optimization problem
         # Fix specified components at final equilibrium composition and find
-        # the initial compositions with minimum change from the initial one 
+        # the initial compositions with minimum change from the initial one
         # that still satisfied the imposed constraints
         fix_pos = list(filter(lambda x : isinstance(x,int), [_ if gas_species[_] in self.equilibrated else None \
                         for _ in range(len(gas_species))]))
@@ -1285,28 +1285,28 @@ class ThermoCorrections(ReactionModelWrapper):
         Aeq2[range(len(self.equilibrated)),fix_pos] = 1.
         Aeq2 = np.concatenate((Aeq,Aeq2),0)
         beq2 = np.concatenate((beq.flatten(),xeq[fix_pos]),0)
-        
+
         # second objective function
         diff_x_xeq = lambda x : np.dot(x-x0,x-x0)
-        
+
         # second jacobian
         jacobian_diff_x_xeq = lambda x : 2.*(x-x0)
-        
+
         # Bounds
         bounds = Bounds(*[[0. for _ in range(len(gas_species))],[np.inf for _ in range(len(gas_species))]])
-    
+
         # Equality constraints 2
         eq_cons2 = {'type': 'eq',
                    'fun' : lambda x: np.dot(Aeq2,x)-beq2,
-                   'jac' : lambda x: Aeq2}       
-    
+                   'jac' : lambda x: Aeq2}
+
         xf = minimize(diff_x_xeq, x0, method='SLSQP', jac=jacobian_diff_x_xeq,
                        constraints=eq_cons2, options={'ftol': 1e-8, 'disp': False, 'maxiter':1000},
-                       bounds=bounds)        
-        
+                       bounds=bounds)
+
         # set pressures
         self.gas_pressures = (xeq.x/sum(xeq.x))*self.pressure
-        
+
         """
         print('x0: {}'.format(x0))
         print('xeq: {}'.format(xeq.x))
@@ -1329,10 +1329,10 @@ def fit_shomate(Ts, Cps, Hs, Ss, params0=[], plot_file = None):
         print("Scipy not installed, returning initial guess")
         return None
         #leastsq = lambda resid, initial, **kwargs: [initial, True]
-    
+
     Ts, Cps, Hs, Ss = [np.array(_) for _ in [Ts,Cps,Hs,Ss]]
     ts = Ts/1000.
-     
+
     # H-collocation matrix
     H_matrix = np.zeros([len(ts),7])
     H_matrix[:,0] = ts
@@ -1342,7 +1342,7 @@ def fit_shomate(Ts, Cps, Hs, Ss, params0=[], plot_file = None):
     H_matrix[:,4] = -1./ts
     H_matrix[:,5] = 1.
     H_matrix[:,6] = 0.
-    
+
     # S-collocation matrix
     S_matrix = np.zeros([len(ts),7])
     S_matrix[:,0] = np.log(ts)
@@ -1352,7 +1352,7 @@ def fit_shomate(Ts, Cps, Hs, Ss, params0=[], plot_file = None):
     S_matrix[:,4] = -1./(2.0*ts**2)
     S_matrix[:,5] = 0.
     S_matrix[:,6] = 1.
-    
+
     # Cp-collocation matrix
     Cp_matrix = np.zeros([len(ts),7])
     Cp_matrix[:,0] = 1.
@@ -1362,12 +1362,12 @@ def fit_shomate(Ts, Cps, Hs, Ss, params0=[], plot_file = None):
     Cp_matrix[:,4] = 1./(ts**2)
     Cp_matrix[:,5] = 0.
     Cp_matrix[:,6] = 0.
-    
+
     M = np.concatenate((H_matrix,-np.diag(ts).dot(S_matrix),np.diag(ts).dot(Cp_matrix)),0)
     b = np.concatenate((Hs,-np.diag(ts).dot(Ss),np.diag(ts).dot(Cps)),0)
-    
+
     A, B, C, D, E, F, G = solve(M.T.dot(M),M.T.dot(b))
-    
+
     if plot_file:
         import pylab as plt
         print('R2: {}, sumE: {}'.format(np.corrcoef(M.dot([A, B, C, D, E, F, G]),b),(M.dot([A, B, C, D, E, F, G])-b).T.dot(M.dot([A, B, C, D, E, F, G])-b)))
@@ -1396,24 +1396,24 @@ def harmonic_to_shomate(frequencies,Tmin,Tmax,resolution):
     frequency_unit_conversion = 1.239842e-4;
     therm = HarmonicThermo([_*frequency_unit_conversion for _ in frequencies])
     _kJmol2eV = 0.01036427
-    
+
     Ts = np.linspace(Tmin,Tmax,resolution)
     Ss = []
     Hs = []
-    ZPE = frequency_unit_conversion*sum(frequencies)/2.0 
+    ZPE = frequency_unit_conversion*sum(frequencies)/2.0
     for t in Ts:
         Ss += [therm.get_entropy(t,verbose=False)/_kJmol2eV*1e3]
         Hs += [(therm.get_internal_energy(t,verbose=False) - ZPE)/_kJmol2eV]
     Cps = pchip_interpolate(Ts,Hs,Ts,der=1)*1000.
-    
-    
+
+
     def _shomate_eq(params,temperature=[]):
         _kJmol2eV=0.01036427
         temperature_ref = 298.15
         def H(T,params):
             A,B,C,D,E,F,G,H = params
             t = T/1000.0
-            H = A*t + (B/2.0)*t**2 + (C/3.0)*t**3 + (D/4.0)*t**4 - E/t + F - H 
+            H = A*t + (B/2.0)*t**2 + (C/3.0)*t**3 + (D/4.0)*t**4 - E/t + F - H
             #kJ/mol
             return H
 
@@ -1429,14 +1429,14 @@ def harmonic_to_shomate(frequencies,Tmin,Tmax,resolution):
             t = T/1000.0
             Cp = A + B*t + C*t**2 + D*t**3 +E/(t**2)
             return Cp
-        
+
         dH = H(temperature,params) - H(temperature_ref,params)
         dS = S(temperature,params)
         Cp_ref = Cp(temperature_ref,params)
         dH = (temperature_ref*Cp_ref/1000.0 + dH)*(_kJmol2eV) #eV
         dS = dS*(_kJmol2eV/1e3) #eV/K
         return dH, dS, Cp_ref
-    
+
     return fit_shomate(Ts,Cps,Hs,Ss)
 
-   
+


### PR DESCRIPTION
This PR contains the following fixes which were created during merging the numbers solver. 
1. Due to `fix_x_star=False` being set by default, the Jacobian generated by the coverage solver was incorrect. Fixed by generating the correct `if-else` statements in the function which generates the strings of the Jacobian.
2. When bisection was used, the `change_x_to_theta` and `get_residual` methods are called, both providing the incorrect residual to the numbers solver (max instead of norm least squares).