### PR TITLE
Update enthalpy_entropy.py

### DIFF
--- a/catmap/thermodynamics/enthalpy_entropy.py
+++ b/catmap/thermodynamics/enthalpy_entropy.py
@@ -1145,7 +1145,7 @@ class ThermoCorrections(ReactionModelWrapper):
             SbykB = (get_entropy(nu,T)/kB)
             return (kB_multiplier - SbykB)**2
 
-        nu_cutoff = fmin_powell(target,10,disp=0)
+        nu_cutoff = fmin_powell(target,10,disp=0)[0] #nu_cutoff should be single-value
         return nu_cutoff
 
     def summary_text(self):


### PR DESCRIPTION
nu_cutoff should be single-valued and not an array. Otherwise, the program might crash when applying the cutoff frequency in harmonic_adsorbate() in the ThermoCorrections class when it is applied, overriding small vibrational frequencies. 
[vibration_error.zip](https://github.com/user-attachments/files/18505588/vibration_error.zip)
Example attached.

