### PR TITLE
Update docstring in mechanism.py

### DIFF
--- a/catmap/analyze/mechanism.py
+++ b/catmap/analyze/mechanism.py
@@ -15,7 +15,7 @@ class MechanismAnalysis(MechanismPlot,ReactionModelWrapper,MapPlot):
     """
     def __init__(self,reaction_model=None):
         """
-        Class for generating potential energy diagrams.
+        Class for generating potential energy diagrams. Pressure corrections (kb*T*log(P)) are included by default.
 
         :param reaction_model: The ReactionModel object to load.
         """


### PR DESCRIPTION
By default, the potential energy diagrams include pressure corrections. Hence, the plotted energies may not be the standard state energies that are used for calculation of rate constants. Added a line in docstring of `catmap.analyze.MechanismAnalysis` to clarify this default setting.
